### PR TITLE
Round vote_average to one decimal place on slider

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -381,7 +381,7 @@ async function displaySlider() {
         <img src="https://image.tmdb.org/t/p/w500${movie.poster_path}" alt="${movie.title}" />
       </a>
       <h4 class="swiper-rating">
-        <i class="fas fa-star text-secondary"></i> ${movie.vote_average} / 10
+        <i class="fas fa-star text-secondary"></i> ${movie.vote_average.toFixed(1)} / 10
       </h4>
     `;
 


### PR DESCRIPTION
- Used the toFixed(1) method to round movie.vote_average to one decimal place on displaySlider function
- This resolves the issue where ratings were showing unnecessary precision (e.g., 7.123 displayed as 7.1)
- Improves user experience by displaying cleaner and more readable movie ratings
